### PR TITLE
[BACKLOG-4070] Update erorrs without re-creating panel

### DIFF
--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -27,8 +27,9 @@
  * @property {Dashboard} dashboard The dashboard object assigned to the prompt
  * @property {Boolean} parametersChanged True if the parameters have changed, False otherwise
  */
-define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/util/util', 'common-ui/util/GUIDHelper', './WidgetBuilder', 'cdf/Dashboard.Clean'],
-    function (_, Base, Logger, DojoNumber, i18n, Utils, GUIDHelper, WidgetBuilder, Dashboard) {
+define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', 'dojo/i18n', 'common-ui/util/util', 'common-ui/util/GUIDHelper', './WidgetBuilder', 'cdf/Dashboard.Clean', './parameters/ParameterDefinitionDiffer'],
+    function (_, Base, Logger, DojoNumber, i18n, Utils, GUIDHelper, WidgetBuilder, Dashboard, ParamDiff) {
+
       /**
        * Creates a Widget calling the widget builder factory
        *
@@ -239,6 +240,8 @@ define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', '
           this.guid = this.promptGUIDHelper.generateGUID();
 
           this.dashboard = new Dashboard();
+
+          this.paramDiffer = new ParamDiff();
 
           this.widgetBuilder = WidgetBuilder;
         },
@@ -569,51 +572,130 @@ define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', '
           }
 
           if (paramDefn) {
-            this.paramDefn = paramDefn;
+            var diff = this.paramDiffer.diff(this.paramDefn, paramDefn);
 
-            // Remove this `PromptPanel`'s components from `Dashboards`.
-            if (this.components) {
-              // Postpone the clearing of removed components if we'll be showing some components.
-              // We'll clear the old components with a special component in front of all other components during init().
-              var postponeClear = this.paramDefn.showParameterUI();
-              this.removeDashboardComponents(this.components, postponeClear);
+            if (diff.changesToMake()) {
+              this.paramDefn = paramDefn;
+              this.update(diff, noAutoAutoSubmit);
+            }
+          }
+        },
 
-              // Create dictionary by parameter name, of topValue of multi-select listboxes, for restoring later, when possible.
-              // But not for mobile, cause the UIs vary. Would need more time to check each.
-              var topValuesByParam;
-              if (!(/android|ipad|iphone/i).test(navigator.userAgent)) {
-                topValuesByParam = this._multiListBoxTopValuesByParam = {};
+        /**
+         * Updates the dashboard and prompt panel based off of differences in the parameter definition
+         * @method update
+         * @param {JSON} diff - contains the differences between the old and new parameter definitions
+         * @param {bool} noAutoAutoSubmit
+         */
+        update: function(diff, noAutoAutoSubmit) {
+
+          // Retrieves a component by a param
+          var _getComponentByParam = (function(param, getPanel) {
+            var parameterName = this.getParameterName(param);
+            return _getComponentByParamName(parameterName, getPanel);
+          }).bind(this);
+
+          var _getComponentByParamName = (function(parameterName, getPanel) {
+            for (var i in this.components) {
+              var component = this.components[i];
+              if (component.parameter === parameterName) {
+                var isPanel = component.type.search("Panel") > -1;
+                if ((getPanel && isPanel) || (!getPanel && !isPanel)) {
+                  return component;
+                }
               }
+            }
+            return null;
+          }).bind(this);
 
-              var focusedParam;
-              _mapComponentsList(this.components, function (component) {
-                if (!component.components && component.param && component.promptType === 'prompt') {
-                  if (!focusedParam) {
-                    var ph = component.placeholder();
-                    if ($(":focus", ph).length) {
-                      focusedParam = component.param.name;
-                    }
-                  }
+          // Removes a single component from dashboard and prompt panel
+          var _removeComponent = (function(component) {
+            this.dashboard.removeComponent(component);
+            for (var i in this.components) {
+              if (this.components[i].name == component.name) {
+                this.components.splice(i, 1);
+                break;
+              }
+            }
+            component.clear();
+          }).bind(this);
 
-                  if (topValuesByParam && component.type === 'SelectMultiComponent') {
-                    var topValue = component.topValue();
-                    if (topValue != null) {
-                      topValuesByParam['_' + component.param.name] = topValue;
-                    }
-                  }
-                } else if (topValuesByParam && component.type === 'ScrollingPromptPanelLayoutComponent') {
-                  // save last scroll position for prompt panel
-                  var scrollTopValue = component.placeholder().children(".prompt-panel").scrollTop();
-                  if (scrollTopValue != null) {
-                    topValuesByParam['_' + component.name] = scrollTopValue;
+          var _addComponent = (function(component) {
+            this.dashboard.addComponent(component);
+            this.components.push(component);
+            this.dashboard.updateComponent(component);
+
+            for (var i in component.components) { // Loop through panel components
+              _addComponent(component.components[i]);
+            }
+          }).bind(this);
+
+          if(diff.toRemove.length > 0) { // To Remove
+            for (var i in diff.toRemove) {
+              var param = diff.toRemove[i];
+              var component = _getComponentByParam(param, true); // get component panel
+
+              if (component != null) {
+                if (component.components) { // Panel component has many components to be cleaned up
+                  for (var j in component.components) { // Loop through panel components
+                    _removeComponent(component.components[j]);
                   }
                 }
-              });
-
-              this._focusedParam = focusedParam;
+                _removeComponent(component);
+                $("#" + component.htmlObject).remove(); // Clean up remaining html object
+              }
             }
 
-            this.init(noAutoAutoSubmit);
+          }
+
+          if(diff.toAdd.length > 0) { // To Add
+            for (var i in diff.toAdd) {
+              var param = diff.toAdd[i];
+              var component = this._buildPanelForParameter(param); // returns a panel component
+
+              var panelComponent = this.dashboard.getComponentByName("prompt" + this.guid);
+              panelComponent.components.push(component);
+
+              // Psuedo update call for panel component, without wiping out other components on update
+              var markup = panelComponent.getMarkupFor(component);
+              var className = component.promptType === 'submit' ? "submit-panel" : "prompt-panel";
+              $("#" + panelComponent.htmlObject + " ." + className).append(markup);
+
+              _addComponent(component);
+            }
+          }
+
+          if(diff.toChangeData.length > 0) { // To Change
+            for (var i in diff.toChangeData) {
+              var param = diff.toChangeData[i];
+
+              // Find selected value in param values list and set it. This works, even if the data in valuesArray is different
+              var selectedValues = param.getSelectedValuesValue();
+              for (var j in selectedValues) {
+                this.setParameterValue(param, selectedValues[j]);
+              }
+
+              var component = _getComponentByParam(param);
+              if (component != null) {
+                // Create new widget to get properly formatted values array
+                var newValuesArray = WidgetBuilder.WidgetBuilder.build({
+                  param: param,
+                  promptPanel: this
+                }, param.attributes["parameter-render-type"]).valuesArray;
+
+                // Compare values array from param (which is formatted into valuesArray) with the current valuesArray
+                if (JSON.stringify(component.valuesArray) !== JSON.stringify(newValuesArray)) {
+                  component.valuesArray = newValuesArray;
+                }
+
+                // Update still needs to be called b/c we are setting a new value above
+                this.dashboard.updateComponent(component);
+              }
+            }
+          }
+
+          if(!noAutoAutoSubmit) {
+            this.submit(this, {isInit: false});
           }
         },
 
@@ -683,23 +765,7 @@ define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', '
                 }
               }
             });
-
-            if (this.components && this.components.length > 0) {
-              // We have old components we MUST call .clear() on to prevent memory leaks. In order to
-              // prevent flickering we must do this during the same execution block as when Dashboards
-              // updates the new components. We'll use our aptly named GarbageCollectorBuilder to handle this.
-              var gc = this.widgetBuilder.build({
-                promptPanel: this,
-                components: this.components
-              }, 'gc');
-
-              if (!gc) {
-                throw 'Cannot create garbage collector';
-              }
-
-              components = [gc].concat(components);
-            }
-
+            
             this.components = components;
             this.dashboard.addComponents(this.components);
             this.dashboard.init();

--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -721,7 +721,7 @@ define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', '
               }
             }
 
-            // need remove component from prompt panel component also
+            // we need to remove components from prompt panel component also
             for (var i in toRemove) {
               var toRemoveComponent = toRemove[i];
               var index = panelComponent.components.indexOf(toRemoveComponent);

--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -222,8 +222,8 @@ define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', '
        * @returns {BaseComponent|null} If no component is found, null will be returned
        */
       var _getComponentByParamName = function(parameterName, getPanel) {
-        for (var i in this.components) {
-          var component = this.components[i];
+        for (var i in this.dashboard.components) {
+          var component = this.dashboard.components[i];
           if (component.parameter === parameterName) {
             var isPanel = component.type.search("Panel") > -1;
             if ((getPanel && isPanel) || (!getPanel && !isPanel)) {
@@ -244,15 +244,6 @@ define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', '
        */
       var _removeComponents = function(components) {
         this.removeDashboardComponents(components);
-        for ( var j in components) {
-          var component = components[j];
-          for ( var i in this.components) {
-            if (this.components[i].name == component.name) {
-              this.components.splice(i, 1);
-              break;
-            }
-          }
-        }
       };
 
       /**
@@ -265,7 +256,6 @@ define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', '
        */
       var _addComponent = function(component) {
         this.dashboard.addComponent(component);
-        this.components.push(component);
         this.dashboard.updateComponent(component);
 
         for (var i in component.components) { // Loop through panel components
@@ -796,7 +786,7 @@ define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', '
               var component = _getComponentByParam.call(this, param);
               if (component != null) {
                 // Create new widget to get properly formatted values array
-                var newValuesArray = WidgetBuilder.WidgetBuilder.build({
+                var newValuesArray = this.widgetBuilder.build({
                   param: param,
                   promptPanel: this
                 }, param.attributes["parameter-render-type"]).valuesArray;
@@ -923,13 +913,19 @@ define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', '
 
             _mapComponents(layout, updateComponent);
 
-            this.components = components;
-            this.dashboard.addComponents(this.components);
+            this.dashboard.addComponents(components);
             this.dashboard.init();
           } else if (this.diff) { // Perform update when there are differences
             this.update(this.diff);
 
-            var promptPanel = this.dashboard.getComponentByName("prompt" + this.guid);
+            if (topValuesByParam) {
+              delete this._multiListBoxTopValuesByParam;
+            }
+
+            if (focusedParam) {
+              delete this._focusedParam;
+            }
+            var layout = this.dashboard.getComponentByName("prompt" + this.guid);
             _mapComponents(layout, updateComponent);
           } else { // Simple parameter value initialization
             this.paramDefn.mapParameters(function (param) {

--- a/package-res/resources/web/prompting/PromptPanel.js
+++ b/package-res/resources/web/prompting/PromptPanel.js
@@ -574,10 +574,8 @@ define(['amd!cdf/lib/underscore', 'cdf/lib/Base', 'cdf/Logger', 'dojo/number', '
           if (paramDefn) {
             var diff = this.paramDiffer.diff(this.paramDefn, paramDefn);
 
-            if (diff.changesToMake()) {
-              this.paramDefn = paramDefn;
-              this.update(diff, noAutoAutoSubmit);
-            }
+            this.paramDefn = paramDefn;
+            this.update(diff, noAutoAutoSubmit);
           }
         },
 

--- a/package-res/resources/web/prompting/components/CompositeComponent.js
+++ b/package-res/resources/web/prompting/components/CompositeComponent.js
@@ -59,6 +59,16 @@ define([ 'cdf/lib/jquery', 'cdf/components/BaseComponent', 'cdf/dashboard/Utils'
     },
 
     /**
+     * Removes the component
+     *
+     * @name CompositeComponent#remove
+     * @method
+     */
+    remove: function() {
+      this.placeholder().remove();
+    },
+
+    /**
      * Gets the CssClass assigned to the component
      *
      * @name CompositeComponent#getClassFor

--- a/package-res/resources/web/prompting/components/ScopedPentahoButtonComponent.js
+++ b/package-res/resources/web/prompting/components/ScopedPentahoButtonComponent.js
@@ -38,7 +38,6 @@
  */
 define([ 'cdf/components/BaseComponent', 'cdf/lib/jquery' ], function(BaseComponent, $) {
   return BaseComponent.extend({
-    viewReportButtonRegistered : false,
 
     /**
      * Renders a submit button element.
@@ -68,8 +67,6 @@ define([ 'cdf/components/BaseComponent', 'cdf/lib/jquery' ], function(BaseCompon
           // Don't let click-event go as first argument.
           this.expression(false);
         }.bind(this)).appendTo($container);
-
-        this.viewReportButtonRegistered = true;
       }
     },
 

--- a/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
+++ b/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
@@ -1,0 +1,115 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Utility to determine the differences of pair ParameterDefinition objects
+ * 
+ * @name ParameterDefinitionDiffer
+ * @class
+ */
+define([], function() {
+  return function() {
+
+    return {
+      _isBehavioralAttrsChanged : function(oldParam, newParam) {
+        // TODO determine enough compare attributes or something else properties
+        var result = JSON.stringify(oldParam.attributes) !== JSON.stringify(newParam.attributes)
+          || oldParam.list !== newParam.list 
+          || oldParam.mandatory !== newParam.mandatory
+          || oldParam.multiSelect !== newParam.multiSelect 
+          || oldParam.strict !== newParam.strict
+          || oldParam.type !== newParam.type;
+        return result;
+      },
+
+      _isDataChanged : function(oldParam, newParam) {
+        // TODO determine what kind of properties are data, only values or not
+        var result = JSON.stringify(oldParam.values) !== JSON.stringify(newParam.values);
+        return result;
+      },
+
+      _isErrorsChanged : function(paramName, oldParamDefn, newParamDefn) {
+        var oldErrors = oldParamDefn.errors[paramName];
+        var newErrors = newParamDefn.errors[paramName];
+        return JSON.stringify(oldErrors) !== JSON.stringify(newErrors);
+      },
+
+      /**
+       * Returns result differences object for oldParamDefn and newParamDefn object. The result contains arrays of
+       * parameters that were added to newParamDefn object, were removed from newParamDefn object and were changed in
+       * newParamDefn object. The result array "toAdd" contains new parameters and means that is needed to create new 
+       * components based this new parameters. The result array "toRemove" contains old parameters and means that is
+       * needed to remove components based this old parameters. The result array "toChangeData" contains parameters
+       * with changed data and means that is needed to update data of existing components based this changed parameters.
+       * 
+       * @name ParameterDefinitionDiffer#diff
+       * @method
+       * @param {ParameterDefinition}
+       *          oldParamDefn The old object instance of {@link ParameterDefinition}
+       * @param {ParameterDefinition}
+       *          newParamDefn The new object instance of {@link ParameterDefinition}
+       * @returns {Object} The result object contains data about added, changed and removed parameters between
+       *          oldParamDefn and newParamDefn object. The result object consists of properties "toAdd",
+       *          "toChangeData", "toRemove". Each property is an array with values of {@link Parameter} type
+       * @example
+       * var differ = new ParameterDefinitionDiffer();
+       * var result = differ.diff(new ParameterDefinition(), new ParameterDefinition());
+       * 
+       * Return Value:
+       * {"toAdd":[],"toChangeData":[],"toRemove":[]}
+       */
+      diff : function(oldParamDefn, newParamDefn) {
+        if (!oldParamDefn || !newParamDefn) {
+          return false;
+        }
+
+        var result = {
+          toAdd : [],
+          toChangeData : [],
+          toRemove : [],
+          changesToMake : function() {
+            return result.toAdd.length > 0 || result.toChangeData.length > 0 || result.toRemove.length > 0;
+          }
+        };
+
+        // find removed parameters
+        oldParamDefn.mapParameters(function(param) {
+          var newParam = newParamDefn.getParameter(param.name);
+          if (!newParam) {
+            result.toRemove.push(param);
+          }
+        });
+        // find new and changed parameters
+        newParamDefn.mapParameters(function(param) {
+          var oldParam = oldParamDefn.getParameter(param.name);
+          if (!oldParam) {
+            result.toAdd.push(param); // found newest parameters
+          } else if (this._isBehavioralAttrsChanged(oldParam, param)
+            || this._isErrorsChanged(param.name, oldParamDefn, newParamDefn)) {
+            // add parameter to remove and add arrays for recreating components
+            result.toRemove.push(oldParam);
+            result.toAdd.push(param);
+          } else if (this._isDataChanged(oldParam, param)) {
+            result.toChangeData.push(param);
+          }
+        }, this);
+
+        return result;
+      }
+    };
+  };
+});

--- a/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
+++ b/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
@@ -131,12 +131,12 @@ define([], function() {
             var oldParam = oldParamDefn.getParameter(param.name);
             if (!oldParam || oldParam.attributes.hidden == 'true') {
               this._fillWrapObj(result, "toAdd", group, param); // found newest parameters
-            } else if (this._isBehavioralAttrsChanged(oldParam, param)
-              || this._isErrorsChanged(param.name, oldParamDefn, newParamDefn)) {
+            } else if (this._isBehavioralAttrsChanged(oldParam, param)) {
               // add parameter to remove and add arrays for recreating components
               this._fillWrapObj(result, "toRemove", group, oldParam);
               this._fillWrapObj(result, "toAdd", group, param);
             } else if (this._isDataChanged(oldParam, param)) {
+              param.isErrorChanged = this._isErrorsChanged(param.name, oldParamDefn, newParamDefn);
               this._fillWrapObj(result, "toChangeData", group, param);
             }
           }

--- a/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
+++ b/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
@@ -48,8 +48,21 @@ define([], function() {
         return JSON.stringify(oldErrors) !== JSON.stringify(newErrors);
       },
 
+      _fillWrapObj : function(result, propName, group, param) {
+        var params = result[propName][group.name] || [];
+        params.push(param);
+        result[propName][group.name] = {
+          group : group,
+          params : params
+        };
+      },
+
+      _hasResultProperties : function(obj) {
+        return Object.keys(obj).length > 0;
+      },
+
       /**
-       * Returns result differences object for oldParamDefn and newParamDefn object. The result contains arrays of
+       * Returns result differences object for oldParamDefn and newParamDefn object. The result contains group and arrays of
        * parameters that were added to newParamDefn object, were removed from newParamDefn object and were changed in
        * newParamDefn object. The result array "toAdd" contains new parameters and means that is needed to create new 
        * components based this new parameters. The result array "toRemove" contains old parameters and means that is
@@ -65,49 +78,72 @@ define([], function() {
        * @returns {Object} The result object contains data about added, changed and removed parameters between
        *          oldParamDefn and newParamDefn object. The result object consists of properties "toAdd",
        *          "toChangeData", "toRemove". Each property is an array with values of {@link Parameter} type
-       * @example
-       * var differ = new ParameterDefinitionDiffer();
-       * var result = differ.diff(new ParameterDefinition(), new ParameterDefinition());
        * 
-       * Return Value:
-       * {"toAdd":[],"toChangeData":[],"toRemove":[]}
+       * An example of using:
+       * <pre><code>
+       *  require([ 'common-ui/prompting/parameters/ParameterDefinitionDiffer' ],
+       *     function(ParameterDefinitionDiffer) {
+       *       var differ = new ParameterDefinitionDiffer();
+       *       var result = differ.diff(new ParameterDefinition(), new ParameterDefinition());
+       *     }
+       *   );
+       * </code></pre>
+       *
+       * An example returned result:
+       * <pre><code>
+       *   {
+       *     "toAdd" : {
+       *       "my_test_group" : {
+       *         "group" : {
+       *           "name" : "my_test_group",
+       *           "label" : undefined,
+       *           "parameters" : []
+       *         },
+       *         params : [] // new parameters to add
+       *       }
+       *     },
+       *     "toChangeData" : {},
+       *     "toRemove" : {}
+       *   }
+       * </code></pre>
        */
       diff : function(oldParamDefn, newParamDefn) {
         if (!oldParamDefn || !newParamDefn) {
           return false;
         }
 
+        var _this = this;
         var result = {
-          toAdd : [],
-          toChangeData : [],
-          toRemove : [],
+          toAdd : {},
+          toChangeData : {},
+          toRemove : {},
           changesToMake : function() {
-            return result.toAdd.length > 0 || result.toChangeData.length > 0 || result.toRemove.length > 0;
+            return _this._hasResultProperties(result.toAdd) || _this._hasResultProperties(result.toChangeData) || _this._hasResultProperties(result.toRemove);
           }
         };
 
         // find removed parameters
-        oldParamDefn.mapParameters(function(param) {
+        oldParamDefn.mapParameters(function(param, group) {
           if (param.attributes.hidden == 'false') {
             var newParam = newParamDefn.getParameter(param.name);
             if (!newParam || newParam.attributes.hidden == 'true') {
-              result.toRemove.push(param);
+              this._fillWrapObj(result, "toRemove", group, param);
             }
           }
         });
         // find new and changed parameters
-        newParamDefn.mapParameters(function(param) {
+        newParamDefn.mapParameters(function(param, group) {
           if (param.attributes.hidden == 'false') {
             var oldParam = oldParamDefn.getParameter(param.name);
             if (!oldParam || oldParam.attributes.hidden == 'true') {
-              result.toAdd.push(param); // found newest parameters
+              this._fillWrapObj(result, "toAdd", group, param); // found newest parameters
             } else if (this._isBehavioralAttrsChanged(oldParam, param)
               || this._isErrorsChanged(param.name, oldParamDefn, newParamDefn)) {
               // add parameter to remove and add arrays for recreating components
-              result.toRemove.push(oldParam);
-              result.toAdd.push(param);
+              this._fillWrapObj(result, "toRemove", group, oldParam);
+              this._fillWrapObj(result, "toAdd", group, param);
             } else if (this._isDataChanged(oldParam, param)) {
-              result.toChangeData.push(param);
+              this._fillWrapObj(result, "toChangeData", group, param);
             }
           }
         }, this);

--- a/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
+++ b/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
@@ -49,12 +49,14 @@ define([], function() {
       },
 
       _fillWrapObj : function(result, propName, group, param) {
-        var params = result[propName][group.name] || [];
-        params.push(param);
-        result[propName][group.name] = {
-          group : group,
-          params : params
-        };
+        if (!result[propName][group.name]) {
+          result[propName][group.name] = {
+            group : group,
+            params : []
+          }
+        }
+
+        result[propName][group.name].params.push(param);
       },
 
       _hasResultProperties : function(obj) {
@@ -116,24 +118,21 @@ define([], function() {
         var result = {
           toAdd : {},
           toChangeData : {},
-          toRemove : {},
-          changesToMake : function() {
-            return _this._hasResultProperties(result.toAdd) || _this._hasResultProperties(result.toChangeData) || _this._hasResultProperties(result.toRemove);
-          }
+          toRemove : {}
         };
 
         // find removed parameters
         oldParamDefn.mapParameters(function(param, group) {
-          if (param.attributes.hidden == 'false') {
+          if (!param.attributes.hidden) { // Can be 'false' or undefined
             var newParam = newParamDefn.getParameter(param.name);
             if (!newParam || newParam.attributes.hidden == 'true') {
               this._fillWrapObj(result, "toRemove", group, param);
             }
           }
-        });
+        }, this);
         // find new and changed parameters
         newParamDefn.mapParameters(function(param, group) {
-          if (param.attributes.hidden == 'false') {
+          if (!param.attributes.hidden) { // Can be 'false' or undefined
             var oldParam = oldParamDefn.getParameter(param.name);
             if (!oldParam || oldParam.attributes.hidden == 'true') {
               this._fillWrapObj(result, "toAdd", group, param); // found newest parameters

--- a/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
+++ b/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
@@ -59,10 +59,6 @@ define([], function() {
         result[propName][group.name].params.push(param);
       },
 
-      _hasResultProperties : function(obj) {
-        return Object.keys(obj).length > 0;
-      },
-
       /**
        * Returns result differences object for oldParamDefn and newParamDefn object. The result contains group and arrays of
        * parameters that were added to newParamDefn object, were removed from newParamDefn object and were changed in
@@ -114,7 +110,6 @@ define([], function() {
           return false;
         }
 
-        var _this = this;
         var result = {
           toAdd : {},
           toChangeData : {},
@@ -123,7 +118,7 @@ define([], function() {
 
         // find removed parameters
         oldParamDefn.mapParameters(function(param, group) {
-          if (!param.attributes.hidden) { // Can be 'false' or undefined
+          if (!param.attributes.hidden || param.attributes.hidden == 'false') { // Can be 'false' or undefined
             var newParam = newParamDefn.getParameter(param.name);
             if (!newParam || newParam.attributes.hidden == 'true') {
               this._fillWrapObj(result, "toRemove", group, param);
@@ -132,7 +127,7 @@ define([], function() {
         }, this);
         // find new and changed parameters
         newParamDefn.mapParameters(function(param, group) {
-          if (!param.attributes.hidden) { // Can be 'false' or undefined
+          if (!param.attributes.hidden || param.attributes.hidden == 'false') { // Can be 'false' or undefined
             var oldParam = oldParamDefn.getParameter(param.name);
             if (!oldParam || oldParam.attributes.hidden == 'true') {
               this._fillWrapObj(result, "toAdd", group, param); // found newest parameters

--- a/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
+++ b/package-res/resources/web/prompting/parameters/ParameterDefinitionDiffer.js
@@ -88,23 +88,27 @@ define([], function() {
 
         // find removed parameters
         oldParamDefn.mapParameters(function(param) {
-          var newParam = newParamDefn.getParameter(param.name);
-          if (!newParam) {
-            result.toRemove.push(param);
+          if (param.attributes.hidden == 'false') {
+            var newParam = newParamDefn.getParameter(param.name);
+            if (!newParam || newParam.attributes.hidden == 'true') {
+              result.toRemove.push(param);
+            }
           }
         });
         // find new and changed parameters
         newParamDefn.mapParameters(function(param) {
-          var oldParam = oldParamDefn.getParameter(param.name);
-          if (!oldParam) {
-            result.toAdd.push(param); // found newest parameters
-          } else if (this._isBehavioralAttrsChanged(oldParam, param)
-            || this._isErrorsChanged(param.name, oldParamDefn, newParamDefn)) {
-            // add parameter to remove and add arrays for recreating components
-            result.toRemove.push(oldParam);
-            result.toAdd.push(param);
-          } else if (this._isDataChanged(oldParam, param)) {
-            result.toChangeData.push(param);
+          if (param.attributes.hidden == 'false') {
+            var oldParam = oldParamDefn.getParameter(param.name);
+            if (!oldParam || oldParam.attributes.hidden == 'true') {
+              result.toAdd.push(param); // found newest parameters
+            } else if (this._isBehavioralAttrsChanged(oldParam, param)
+              || this._isErrorsChanged(param.name, oldParamDefn, newParamDefn)) {
+              // add parameter to remove and add arrays for recreating components
+              result.toRemove.push(oldParam);
+              result.toAdd.push(param);
+            } else if (this._isDataChanged(oldParam, param)) {
+              result.toChangeData.push(param);
+            }
           }
         }, this);
 

--- a/package-res/resources/web/test/prompting/PromptPanelSpec.js
+++ b/package-res/resources/web/test/prompting/PromptPanelSpec.js
@@ -365,6 +365,8 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           spyOn(panel, "init");
           spyOn(panel, "removeDashboardComponents");
           spyOn(window, "setTimeout");
+          spyOn(panel.paramDiffer, "diff");
+          spyOn(panel, "update");
         });
 
         it("should not refresh if exists waitingForInit parameter", function() {
@@ -391,7 +393,6 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           panel.refresh(paramDefn, noAutoAutoSubmit);
           expect(panel.paramDefn).toBe(paramDefn);
           expect(window.setTimeout).not.toHaveBeenCalled();
-          expect(panel.init).toHaveBeenCalledWith(noAutoAutoSubmit);
           expect(panel.removeDashboardComponents).not.toHaveBeenCalled();
         });
 
@@ -403,8 +404,6 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           panel.refresh(paramDefn);
           expect(panel.paramDefn).toBe(paramDefn);
           expect(window.setTimeout).not.toHaveBeenCalled();
-          expect(panel.init).toHaveBeenCalledWith(undefined);
-          expect(panel.removeDashboardComponents).toHaveBeenCalled();
           expect(panel._focusedParam).not.toBeDefined();
         });
 
@@ -423,11 +422,6 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           panel.refresh(paramDefn);
           expect(panel.paramDefn).toBe(paramDefn);
           expect(window.setTimeout).not.toHaveBeenCalled();
-          expect(panel.init).toHaveBeenCalledWith(undefined);
-          expect(panel.removeDashboardComponents).toHaveBeenCalled();
-          expect(panel._focusedParam).toBe(comp.param.name);
-          expect(comp.placeholder).toHaveBeenCalled();
-          expect(window.$).toHaveBeenCalled();
         });
 
         it("should init also with components for ScrollingPromptPanelLayoutComponent", function() {
@@ -449,10 +443,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           panel.refresh(paramDefn);
           expect(panel.paramDefn).toBe(paramDefn);
           expect(window.setTimeout).not.toHaveBeenCalled();
-          expect(panel.init).toHaveBeenCalledWith(undefined);
-          expect(panel.removeDashboardComponents).toHaveBeenCalled();
           expect(panel._focusedParam).not.toBeDefined();
-          expect(comp.placeholder).toHaveBeenCalled();
           expect(window.$).not.toHaveBeenCalled();
         });
       });

--- a/package-res/resources/web/test/prompting/PromptPanelSpec.js
+++ b/package-res/resources/web/test/prompting/PromptPanelSpec.js
@@ -462,7 +462,6 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
 
         it("should not init dashboard without showing panel and without submitting", function() {
           panel.init(true);
-          expect(panel.components).not.toBeDefined();
           expect(paramDefn.showParameterUI).toHaveBeenCalled();
           expect(paramDefn.mapParameters).toHaveBeenCalled();
           expect(dash.addComponents).not.toHaveBeenCalled();
@@ -473,7 +472,6 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
 
         it("should not init dashboard without showing panel and with submitting", function() {
           panel.init();
-          expect(panel.components).not.toBeDefined();
           expect(paramDefn.showParameterUI).toHaveBeenCalled();
           expect(paramDefn.mapParameters).toHaveBeenCalled();
           expect(dash.addComponents).not.toHaveBeenCalled();
@@ -493,7 +491,6 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           panel.init(true);
           expect(panel._multiListBoxTopValuesByParam).not.toBeDefined();
           expect(panel._focusedParam).not.toBeDefined();
-          expect(panel.components.length > 0).toBeTruthy();
           expect(paramDefn.showParameterUI).toHaveBeenCalled();
           expect(paramDefn.mapParameters).not.toHaveBeenCalled();
           expect(dash.addComponents).toHaveBeenCalled();
@@ -704,7 +701,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
             componentSpy.parameter = paramName;
             componentSpy.type = "TestPanel";
 
-            panel.components = [componentSpy];
+            panel.dashboard.components = [componentSpy];
             panel.guid = guid;
           });
 
@@ -730,7 +727,6 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
                 return panelSpy;
               }
             });
-
             spyOn(panel, "removeDashboardComponents");
 
             panel._removeComponentsByDiff(diffSpy.toRemove);

--- a/package-res/resources/web/test/prompting/PromptPanelSpec.js
+++ b/package-res/resources/web/test/prompting/PromptPanelSpec.js
@@ -651,6 +651,56 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           expect(panel.dashboard.components[0].listeners.length).toBe(0);
         });
       });
+
+      describe("update", function() {
+        var diffSpy;
+        beforeEach(function() {
+          diffSpy = jasmine.createSpy("diffSpy");
+          diffSpy.toRemove = {};
+          diffSpy.toAdd = {};
+          diffSpy.toChangeData = {};
+        });
+
+        it("should not call every update call", function() {
+          spyOn(panel, "_removeComponentsByDiff");
+          spyOn(panel, "_addComponentsByDiff");
+          spyOn(panel, "_changeComponentsByDiff");
+
+          panel.update(diffSpy);
+
+          expect(panel._removeComponentsByDiff).not.toHaveBeenCalledWith(diffSpy.toRemove);
+          expect(panel._addComponentsByDiff).not.toHaveBeenCalledWith(diffSpy.toAdd);
+          expect(panel._changeComponentsByDiff).not.toHaveBeenCalledWith(diffSpy.toChangeData);
+        });
+
+        it("should call every update call", function() {
+          spyOn(panel, "_removeComponentsByDiff");
+          spyOn(panel, "_addComponentsByDiff");
+          spyOn(panel, "_changeComponentsByDiff");
+
+          diffSpy.toRemove.test = {};
+          diffSpy.toAdd.test = {};
+          diffSpy.toChangeData.test = {};
+
+          panel.update(diffSpy);
+
+          expect(panel._removeComponentsByDiff).toHaveBeenCalledWith(diffSpy.toRemove);
+          expect(panel._addComponentsByDiff).toHaveBeenCalledWith(diffSpy.toAdd);
+          expect(panel._changeComponentsByDiff).toHaveBeenCalledWith(diffSpy.toChangeData);
+        });
+
+        describe("_removeComponentsByDiff", function() {
+
+        });
+
+        describe("_addComponentsByDiff", function() {
+
+        });
+
+        describe("_changeComponentsByDiff", function() {
+
+        });
+      });
     });
   });
 });

--- a/package-res/resources/web/test/prompting/PromptPanelSpec.js
+++ b/package-res/resources/web/test/prompting/PromptPanelSpec.js
@@ -697,7 +697,7 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
               params : [paramSpy]
             };
 
-            componentSpy = jasmine.createSpy("componentSpy");
+            componentSpy = jasmine.createSpyObj("componentSpy", [ "clear" ]);
             componentSpy.parameter = paramName;
             componentSpy.type = "TestPanel";
 
@@ -706,16 +706,16 @@ define([ 'dojo/number', 'dojo/i18n', 'common-ui/prompting/PromptPanel',
           });
 
           it ("should successfully remove the provided components", function() {
-            var groupPanelSpy = jasmine.createSpy("groupPanelSpy");
+            var groupPanelSpy = jasmine.createSpyObj("groupPanelSpy", [ "clear" ]);
             groupPanelSpy.components = [componentSpy];
             spyOn(groupPanelSpy.components, "indexOf").and.callThrough();
             spyOn(groupPanelSpy.components, "splice").and.callThrough();
 
-            var submitComponentSpy = jasmine.createSpy("submitComponentSpy");
+            var submitComponentSpy = jasmine.createSpyObj("submitComponentSpy", [ "clear" ]);
             submitComponentSpy.promptType = "submit";
             submitComponentSpy.type = "FlowPromptLayoutComponent";
 
-            var panelSpy = jasmine.createSpy("panelSpy");
+            var panelSpy = jasmine.createSpyObj("panelSpy", [ "clear" ]);
             panelSpy.components = [submitComponentSpy];
             spyOn(panelSpy.components, "splice").and.callThrough();
 

--- a/package-res/resources/web/test/prompting/components/ScopedPentahoButtonComponentSpec.js
+++ b/package-res/resources/web/test/prompting/components/ScopedPentahoButtonComponentSpec.js
@@ -43,7 +43,6 @@ define([ 'common-ui/prompting/components/ScopedPentahoButtonComponent', 'cdf/lib
       beforeEach(function() {
         comp = new ScopedPentahoButtonComponent();
         comp.htmlObject = id;
-        comp.viewReportButtonRegistered = false;
         comp.label = testLabel;
         spyOn($.fn, "empty");
         spyOn($.fn, "text").and.returnValue(spyElem);
@@ -59,7 +58,6 @@ define([ 'common-ui/prompting/components/ScopedPentahoButtonComponent', 'cdf/lib
       });
 
       afterEach(function() {
-        expect(comp.viewReportButtonRegistered).toBeTruthy();
         expect($.fn.empty).toHaveBeenCalled();
         expect($.fn.text).toHaveBeenCalledWith(testLabel);
         expect(spyElem.bind.calls.argsFor(0)).toEqual([ "mousedown", jasmine.any(Function) ]);

--- a/package-res/resources/web/test/prompting/parameters/ParameterDefinitionDifferSpec.js
+++ b/package-res/resources/web/test/prompting/parameters/ParameterDefinitionDifferSpec.js
@@ -1,0 +1,294 @@
+/*!
+ * Copyright 2010 - 2015 Pentaho Corporation.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+define([ 'common-ui/prompting/parameters/Parameter', 'common-ui/prompting/parameters/ParameterValue',
+    'common-ui/prompting/parameters/ParameterGroup', 'common-ui/prompting/parameters/ParameterDefinition',
+    'common-ui/prompting/parameters/ParameterDefinitionDiffer' ], function(Parameter, ParameterValue, ParameterGroup,
+                                                                           ParameterDefinition, ParameterDefinitionDiffer) {
+
+    describe("ParameterDefinitionDiffer", function() {
+        var parameterDefinitionDiffer;
+
+        var createParam = function(arrayCount, type, list, mandatory, multiSelect, strict) {
+            var param = new Parameter();
+            for (var i = 0; i < arrayCount; i++) {
+                param.attributes['attr' + i] = "attr" + i;
+                var value = new ParameterValue();
+                value.type = type;
+                value.label = "label" + i;
+                value.value = "label" + i;
+                value.selected = false;
+                param.values.push(value);
+            }
+            param.type = type;
+            param.list = list;
+            param.mandatory = mandatory;
+            param.multiSelect = multiSelect;
+            param.strict = strict;
+            return param;
+        };
+
+        var createParamDefn = function(paramName, arrayCount) {
+            var paramDefn = new ParameterDefinition();
+            paramDefn.errors[paramName] = [];
+            for (var i = 0; i < arrayCount; i++) {
+                paramDefn.errors[paramName].push("error" + i);
+            }
+            var group = new ParameterGroup();
+            var param = createParam(arrayCount, "String", true, true, true, true);
+            param.name = paramName;
+            group.parameters.push(param);
+            paramDefn.parameterGroups.push(group);
+            return paramDefn;
+        };
+
+        beforeEach(function() {
+            parameterDefinitionDiffer = new ParameterDefinitionDiffer();
+        });
+
+        describe("_isBehavioralAttrsChanged", function() {
+            var paramOld, paramNew;
+
+            beforeEach(function() {
+                paramOld = createParam(2, "String", true, true, true, true);
+                paramNew = createParam(2, "String", true, true, true, true);
+            });
+
+            it("should return false for parameters with equal attributes and properties", function() {
+                var result = parameterDefinitionDiffer._isBehavioralAttrsChanged(paramOld, paramNew);
+                expect(result).toBeFalsy();
+            });
+
+            it("should return true for different attributes", function() {
+                paramNew.attributes.attr0 = "new";
+                var result = parameterDefinitionDiffer._isBehavioralAttrsChanged(paramOld, paramNew);
+                expect(result).toBeTruthy();
+            });
+
+            it("should return true for different type property", function() {
+                paramNew.type = "Number";
+                var result = parameterDefinitionDiffer._isBehavioralAttrsChanged(paramOld, paramNew);
+                expect(result).toBeTruthy();
+            });
+
+            it("should return true for different list property", function() {
+                paramNew.list = false;
+                var result = parameterDefinitionDiffer._isBehavioralAttrsChanged(paramOld, paramNew);
+                expect(result).toBeTruthy();
+            });
+
+            it("should return true for different mandatory property", function() {
+                paramNew.mandatory = false;
+                var result = parameterDefinitionDiffer._isBehavioralAttrsChanged(paramOld, paramNew);
+                expect(result).toBeTruthy();
+            });
+
+            it("should return true for different multiSelect property", function() {
+                paramNew.multiSelect = false;
+                var result = parameterDefinitionDiffer._isBehavioralAttrsChanged(paramOld, paramNew);
+                expect(result).toBeTruthy();
+            });
+
+            it("should return true for different strict property", function() {
+                paramNew.strict = false;
+                var result = parameterDefinitionDiffer._isBehavioralAttrsChanged(paramOld, paramNew);
+                expect(result).toBeTruthy();
+            });
+        });
+
+        describe("_isDataChanged", function() {
+            var paramOld, paramNew;
+
+            beforeEach(function() {
+                paramOld = createParam(2, "String", true, true, true, true);
+                paramNew = createParam(2, "String", true, true, true, true);
+            });
+
+            it("should return false for equal values", function() {
+                var result = parameterDefinitionDiffer._isDataChanged(paramOld, paramNew);
+                expect(result).toBeFalsy();
+            });
+
+            it("should return true for diffrenet values", function() {
+                paramNew.values[0].selected = true;
+                var result = parameterDefinitionDiffer._isDataChanged(paramOld, paramNew);
+                expect(result).toBeTruthy();
+            });
+        });
+
+        describe("_isErrorsChanged", function() {
+            var paramName = "paramName";
+            var paramDefnOld, paramDefnNew;
+
+            beforeEach(function() {
+                paramDefnOld = createParamDefn(paramName, 2);
+                paramDefnNew = createParamDefn(paramName, 2);
+            });
+
+            it("should return false for equal errors", function() {
+                var result = parameterDefinitionDiffer._isErrorsChanged(paramName, paramDefnOld, paramDefnNew);
+                expect(result).toBeFalsy();
+            });
+
+            it("should return true for diffrenet errors", function() {
+                paramDefnNew.errors[paramName].push("new error");
+                var result = parameterDefinitionDiffer._isErrorsChanged(paramName, paramDefnOld, paramDefnNew);
+                expect(result).toBeTruthy();
+            });
+        });
+
+        describe("diff", function() {
+            var paramName = "paramName";
+            var paramDefnOld, paramDefnNew;
+
+            beforeEach(function() {
+                paramDefnOld = createParamDefn(paramName, 2);
+                paramDefnNew = createParamDefn(paramName, 2);
+            });
+
+            describe("should return false result", function() {
+                var result;
+
+                it("if first param is undefined", function() {
+                    result = parameterDefinitionDiffer.diff(undefined, {});
+                });
+
+                it("if second param is undefined", function() {
+                    result = parameterDefinitionDiffer.diff({});
+                });
+
+                it("if both parameters are undefined", function() {
+                    result = parameterDefinitionDiffer.diff();
+                });
+
+                afterEach(function() {
+                    expect(result).toBeFalsy();
+                });
+            });
+
+            it("should return result with added and removed parameters", function() {
+                spyOn(paramDefnNew, "getParameter").and.returnValue(false);
+                spyOn(paramDefnOld, "getParameter").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isBehavioralAttrsChanged").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isErrorsChanged").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isDataChanged").and.returnValue(false);
+
+                var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew);
+
+                expect(parameterDefinitionDiffer._isBehavioralAttrsChanged).not.toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isErrorsChanged).not.toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isDataChanged).not.toHaveBeenCalled();
+                expect(result).toBeDefined();
+                expect(Object.keys(result.toAdd).length).toBe(1);
+                expect(Object.keys(result.toChangeData).length).toBe(0);
+                expect(Object.keys(result.toRemove).length).toBe(1);
+            });
+
+            it("should return result with added and removed parameters by changed attributes", function() {
+                var paramSpy = jasmine.createSpy("paramSpy");
+                paramSpy.attributes = {
+                    hidden : true
+                };
+
+                spyOn(paramDefnNew, "getParameter").and.returnValue(paramSpy);
+                spyOn(paramDefnOld, "getParameter").and.returnValue(paramSpy);
+                spyOn(parameterDefinitionDiffer, "_isBehavioralAttrsChanged").and.returnValue(true);
+                spyOn(parameterDefinitionDiffer, "_isErrorsChanged").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isDataChanged").and.returnValue(false);
+
+                var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew);
+
+                expect(parameterDefinitionDiffer._isBehavioralAttrsChanged).toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isErrorsChanged).not.toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isDataChanged).not.toHaveBeenCalled();
+                expect(result).toBeDefined();
+                expect(Object.keys(result.toAdd).length).toBe(1);
+                expect(Object.keys(result.toChangeData).length).toBe(0);
+                expect(Object.keys(result.toRemove).length).toBe(1);
+            });
+
+            it("should return result with added and removed parameters by changed errors", function() {
+                var paramSpy = jasmine.createSpy("paramSpy");
+                paramSpy.attributes = {
+                    hidden : true
+                };
+
+                spyOn(paramDefnNew, "getParameter").and.returnValue(paramSpy);
+                spyOn(paramDefnOld, "getParameter").and.returnValue(paramSpy);
+                spyOn(parameterDefinitionDiffer, "_isBehavioralAttrsChanged").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isErrorsChanged").and.returnValue(true);
+                spyOn(parameterDefinitionDiffer, "_isDataChanged").and.returnValue(false);
+
+                var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew);
+
+                expect(parameterDefinitionDiffer._isBehavioralAttrsChanged).toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isErrorsChanged).toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isDataChanged).not.toHaveBeenCalled();
+                expect(result).toBeDefined();
+                expect(Object.keys(result.toAdd).length).toBe(1);
+                expect(Object.keys(result.toChangeData).length).toBe(0);
+                expect(Object.keys(result.toRemove).length).toBe(1);
+            });
+
+            it("should return result with changed parameters by changed values", function() {
+                var paramSpy = jasmine.createSpy("paramSpy");
+                paramSpy.attributes = {
+                    hidden : true
+                };
+
+                spyOn(paramDefnNew, "getParameter").and.returnValue(paramSpy);
+                spyOn(paramDefnOld, "getParameter").and.returnValue(paramSpy);
+                spyOn(parameterDefinitionDiffer, "_isBehavioralAttrsChanged").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isErrorsChanged").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isDataChanged").and.returnValue(true);
+
+                var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew);
+
+                expect(parameterDefinitionDiffer._isBehavioralAttrsChanged).toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isErrorsChanged).toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isDataChanged).toHaveBeenCalled();
+                expect(result).toBeDefined();
+                expect(Object.keys(result.toAdd).length).toBe(0);
+                expect(Object.keys(result.toChangeData).length).toBe(1);
+                expect(Object.keys(result.toRemove).length).toBe(0);
+            });
+
+            it("should return result without changes", function() {
+                var paramSpy = jasmine.createSpy("paramSpy");
+                paramSpy.attributes = {
+                    hidden : true
+                };
+
+                spyOn(paramDefnNew, "getParameter").and.returnValue(paramSpy);
+                spyOn(paramDefnOld, "getParameter").and.returnValue(paramSpy);
+                spyOn(parameterDefinitionDiffer, "_isBehavioralAttrsChanged").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isErrorsChanged").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isDataChanged").and.returnValue(false);
+
+                var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew);
+
+                expect(parameterDefinitionDiffer._isBehavioralAttrsChanged).toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isErrorsChanged).toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isDataChanged).toHaveBeenCalled();
+                expect(result).toBeDefined();
+                expect(Object.keys(result.toAdd).length).toBe(0);
+                expect(Object.keys(result.toChangeData).length).toBe(0);
+                expect(Object.keys(result.toRemove).length).toBe(0);
+            });
+        });
+    });
+});

--- a/package-res/resources/web/test/prompting/parameters/ParameterDefinitionDifferSpec.js
+++ b/package-res/resources/web/test/prompting/parameters/ParameterDefinitionDifferSpec.js
@@ -231,17 +231,17 @@ define([ 'common-ui/prompting/parameters/Parameter', 'common-ui/prompting/parame
                 spyOn(paramDefnOld, "getParameter").and.returnValue(paramSpy);
                 spyOn(parameterDefinitionDiffer, "_isBehavioralAttrsChanged").and.returnValue(false);
                 spyOn(parameterDefinitionDiffer, "_isErrorsChanged").and.returnValue(true);
-                spyOn(parameterDefinitionDiffer, "_isDataChanged").and.returnValue(false);
+                spyOn(parameterDefinitionDiffer, "_isDataChanged").and.returnValue(true);
 
                 var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew);
 
                 expect(parameterDefinitionDiffer._isBehavioralAttrsChanged).toHaveBeenCalled();
                 expect(parameterDefinitionDiffer._isErrorsChanged).toHaveBeenCalled();
-                expect(parameterDefinitionDiffer._isDataChanged).not.toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isDataChanged).toHaveBeenCalled();
                 expect(result).toBeDefined();
-                expect(Object.keys(result.toAdd).length).toBe(1);
-                expect(Object.keys(result.toChangeData).length).toBe(0);
-                expect(Object.keys(result.toRemove).length).toBe(1);
+                expect(Object.keys(result.toAdd).length).toBe(0);
+                expect(Object.keys(result.toChangeData).length).toBe(1);
+                expect(Object.keys(result.toRemove).length).toBe(0);
             });
 
             it("should return result with changed parameters by changed values", function() {
@@ -282,7 +282,7 @@ define([ 'common-ui/prompting/parameters/Parameter', 'common-ui/prompting/parame
                 var result = parameterDefinitionDiffer.diff(paramDefnOld, paramDefnNew);
 
                 expect(parameterDefinitionDiffer._isBehavioralAttrsChanged).toHaveBeenCalled();
-                expect(parameterDefinitionDiffer._isErrorsChanged).toHaveBeenCalled();
+                expect(parameterDefinitionDiffer._isErrorsChanged).not.toHaveBeenCalled();
                 expect(parameterDefinitionDiffer._isDataChanged).toHaveBeenCalled();
                 expect(result).toBeDefined();
                 expect(Object.keys(result.toAdd).length).toBe(0);


### PR DESCRIPTION
What was done:
1. Refactored processing error's components without re-creating panel.
2. Fix clearing html elements when remove components.
3. Small refactoring
@krivera-pentaho please take a look
